### PR TITLE
Upgrade PHP 7.1 & add git for composer

### DIFF
--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:edge
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -14,6 +14,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ENV COMPOSER_HASH=669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410
 ENV PHPRUN_DEPS \
   curl \
+  git \
   mariadb-client \
   patch \
   sqlite


### PR DESCRIPTION
- use `edge` base to get latest php
- git is needed for composer so do not install it each time