### PR TITLE
Move openssh-client to base image & make *-git obsolete

### DIFF
--- a/php56-git/Dockerfile
+++ b/php56-git/Dockerfile
@@ -10,7 +10,3 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
   org.label-schema.description="PHP Alpine for Drupal - composer & drush & git" \
   org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
   maintainer="Andy Postnikov <andypost@ya.ru>"
-
-RUN apk add --no-cache \
-  git \
-  openssh-client

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -14,7 +14,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ENV COMPOSER_HASH=669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410
 ENV PHPRUN_DEPS \
   curl \
+  git \
   mariadb-client \
+  openssh-client \
   openssl \
   patch \
   sqlite

--- a/php7-git/Dockerfile
+++ b/php7-git/Dockerfile
@@ -10,7 +10,3 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
   org.label-schema.description="PHP Alpine for Drupal - composer & drush & git" \
   org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
   maintainer="Andy Postnikov <andypost@ya.ru>"
-
-RUN apk add --no-cache \
-  git \
-  openssh-client

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -14,7 +14,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ENV COMPOSER_HASH=669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410
 ENV PHPRUN_DEPS \
   curl \
+  git \
   mariadb-client \
+  openssh-client \
   patch \
   sqlite
 

--- a/php71-git/Dockerfile
+++ b/php71-git/Dockerfile
@@ -10,7 +10,3 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
   org.label-schema.description="PHP Alpine for Drupal - composer & drush & git" \
   org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
   maintainer="Andy Postnikov <andypost@ya.ru>"
-
-RUN apk add --no-cache \
-  git \
-  openssh-client

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPRUN_DEPS \
   curl \
   git \
   mariadb-client \
+  openssh-client \
   patch \
   sqlite
 


### PR DESCRIPTION
- git required for composer
- openssh-client (`ssh` command) is only leftover in *-git images