### PR TITLE
Use latest php with xdebug, drush8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 NAME = skilldlabs/php
-TAGS = 56 56-fpm 56-git 7 7-fpm 7-git 71 71-fpm 71-fpm-dev 71-git
+TAGS ?= 56 56-fpm 56-git 7 7-fpm 7-git 71 71-fpm 71-fpm-dev 71-git
 
 .PHONY: all build push
 
 all: build push
 
 build:
+	@echo "Building images for tags: $(TAGS)"
 	set -e; for i in $(TAGS); do printf "\nBuilding $(NAME):php$$i \n\n"; cd php$$i; docker build -t $(NAME):$$i --no-cache --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` .; cd ..; done
 
 push:
+	@echo "Pushing images for tags: $(TAGS)"
 	set -e; for i in $(TAGS); do printf "\nPushing $(NAME):$$i \n\n"; docker push $(NAME):$$i; done

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = skilldlabs/php
-TAGS = 56 56-fpm 56-git 7 7-fpm 7-git 71 71-fpm 71-git
+TAGS = 56 56-fpm 56-git 7 7-fpm 7-git 71 71-fpm 71-fpm-dev 71-git
 
 .PHONY: all build push
 

--- a/php56-fpm/Dockerfile
+++ b/php56-fpm/Dockerfile
@@ -44,18 +44,21 @@ RUN set -e \
   php5-pdo_mysql \
   php5-pdo_sqlite \
   php5-phar \
-  php5-xdebug \
   php5-xml \
   php5-zlib \
   $PHPRUN_DEPS \
-  && rm -fr /var/cache/apk/* \
+  && apk add --no-cache make gcc g++ autoconf php5-dev php5-pear --virtual .php-xdebug \
+  && sed -ie 's/-n//g' /usr/bin/pecl \
+  && CFLAGS="-fstack-protector-strong -fpic -fpie -O2" CPPFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie" pecl install xdebug-2.5.5 \
+  && apk del .php-xdebug \
+  && rm -fr /var/cache/apk/* /usr/include /usr/share/pear /tmp/pear \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php \
   --install-dir=/usr/bin \
   --filename=composer \
   && php -r "unlink('composer-setup.php');" \
-  && php -r "copy('http://files.drush.org/drush.phar', '/usr/bin/drush');" \
+  && php -r "copy('https://github.com/drush-ops/drush/releases/download/8.1.16/drush.phar', '/usr/bin/drush');" \
   && chmod +x /usr/bin/drush
 
 COPY php-fpm.conf /etc/php5/

--- a/php56-fpm/Dockerfile
+++ b/php56-fpm/Dockerfile
@@ -68,4 +68,4 @@ WORKDIR /var/www/html
 
 EXPOSE 9000
 
-CMD ["php-fpm", "-F"]
+CMD ["php-fpm5", "-F"]

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -40,18 +40,21 @@ RUN set -e \
   php5-pdo_mysql \
   php5-pdo_sqlite \
   php5-phar \
-  php5-xdebug \
   php5-xml \
   php5-zlib \
   $PHPRUN_DEPS \
-  && rm -fr /var/cache/apk/* \
+  && apk add --no-cache make gcc g++ autoconf php5-dev php5-pear --virtual .php-xdebug \
+  && sed -ie 's/-n//g' /usr/bin/pecl \
+  && CFLAGS="-fstack-protector-strong -fpic -fpie -O2" CPPFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie" pecl install xdebug-2.5.5 \
+  && apk del .php-xdebug \
+  && rm -fr /var/cache/apk/* /usr/include /usr/share/pear /tmp/pear \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php \
   --install-dir=/usr/bin \
   --filename=composer \
   && php -r "unlink('composer-setup.php');" \
-  && php -r "copy('http://files.drush.org/drush.phar', '/usr/bin/drush');" \
+  && php -r "copy('https://github.com/drush-ops/drush/releases/download/8.1.16/drush.phar', '/usr/bin/drush');" \
   && chmod +x /usr/bin/drush
 
 COPY php.ini /etc/php5/conf.d/xx-drupal.ini

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -42,12 +42,15 @@ RUN set -e \
   php7-pdo_sqlite \
   php7-phar \
   php7-session \
-  php7-xdebug \
   php7-xml \
   php7-xmlreader \
   php7-zlib \
   $PHPRUN_DEPS \
-  && rm -fr /var/cache/apk/* \
+  && apk add --no-cache make gcc g++ autoconf php7-dev php7-pear --virtual .php-xdebug \
+  && sed -ie 's/-n//g' /usr/bin/pecl \
+  && CFLAGS="-fstack-protector-strong -fpic -fpie -O2" CPPFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie" pecl install xdebug \
+  && apk del .php-xdebug \
+  && rm -fr /var/cache/apk/* /usr/include /usr/share/pear /tmp/pear \
   && ln -s /usr/bin/php7 /usr/bin/php \
   && php7 -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php7 -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
@@ -55,7 +58,7 @@ RUN set -e \
   --install-dir=/usr/bin \
   --filename=composer \
   && php7 -r "unlink('composer-setup.php');" \
-  && php7 -r "copy('http://files.drush.org/drush.phar', '/usr/bin/drush');" \
+  && php7 -r "copy('https://github.com/drush-ops/drush/releases/download/8.1.16/drush.phar', '/usr/bin/drush');" \
   && chmod +x /usr/bin/drush
 
 COPY php.ini /etc/php7/conf.d/xx-drupal.ini

--- a/php71-fpm-dev/Dockerfile
+++ b/php71-fpm-dev/Dockerfile
@@ -1,0 +1,14 @@
+FROM skilldlabs/php:71-fpm
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.name="docker-php" \
+  org.label-schema.description="PHP Alpine for Drupal - composer, drush, git, xhprof" \
+  org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
+  maintainer="Andy Postnikov <andypost@ya.ru>"
+
+RUN apk add --no-cache -X http://nl.alpinelinux.org/alpine/edge/testing php7-tideways_xhprof

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -67,7 +67,7 @@ RUN set -e \
   --install-dir=/usr/bin \
   --filename=composer \
   && php -r "unlink('composer-setup.php');" \
-  && php -r "copy('http://files.drush.org/drush.phar', '/usr/bin/drush');" \
+  && php -r "copy('https://github.com/drush-ops/drush/releases/download/8.1.16/drush.phar', '/usr/bin/drush');" \
   && chmod +x /usr/bin/drush
 
 COPY php.ini /etc/php7/conf.d/xx-drupal.ini


### PR DESCRIPTION
- Using `edge` enables latest releases
- `drush` no longer delivered fron old URL
- `php5-xdebug` no longer maintained by Alpine and `php7-xdebug` for 7.0 is outdated