### PR TITLE
php5.6-fpm fpm filename update

### DIFF
--- a/php56-fpm/Dockerfile
+++ b/php56-fpm/Dockerfile
@@ -69,4 +69,4 @@ WORKDIR /var/www/html
 
 EXPOSE 9000
 
-CMD ["php-fpm", "-F"]
+CMD ["php-fpm5", "-F"]


### PR DESCRIPTION
Issue:

`ERROR: for php  Cannot start service php: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"php-fpm\": executable file not found in $PATH": unknown`

On Alpine:edge the file name has changed and we don't have a link for `php-fpm` anymore. So we need to use `/usr/bin/php-fpm5` instead

Source: https://pkgs.alpinelinux.org/contents?file=&path=&name=php5-fpm&branch=edge&repo=community&arch=x86