### PR TITLE
Remove enpty continuation lines

### DIFF
--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -47,7 +47,6 @@ RUN set -e \
   php7-xmlwriter \
   php7-zlib \
   $PHPRUN_DEPS \
-
 # build xdebug
   && apk add --upgrade --no-cache \
 #  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
@@ -58,7 +57,6 @@ RUN set -e \
 # clean-up
   && apk del --no-cache .php-build \
   && rm -rf /usr/include /usr/share/pear /tmp/pear \
-
   && rm -fr /var/cache/apk/* \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -47,7 +47,6 @@ RUN set -e \
   php7-xmlwriter \
   php7-zlib \
   $PHPRUN_DEPS \
-
 # build xdebug & apcu
 #  && apk add --upgrade --no-cache \
 #  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
@@ -58,7 +57,6 @@ RUN set -e \
 # clean-up
 #  && apk del --no-cache .php-build \
 #  && rm -rf /usr/include /usr/share/pear /tmp/pear \
-
   && rm -fr /var/cache/apk/* \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \


### PR DESCRIPTION
Empty lines shows error in 18.05 docker

```
[WARNING]: Empty continuation line found in:
    RUN set -e   && apk add --upgrade --no-cache   php7   php7-apcu   php7-bcmath   php7-ctype   php7-curl   php7-dom   php7-gd   php7-gmp   php7-iconv   php7-json   php7-mbstring   php7-opcache   php7-openssl   php7-pcntl   php7-pdo_mysql   php7-pdo_sqlite   php7-phar   php7-session   php7-simplexml   php7-tokenizer   php7-xdebug   php7-xml   php7-xmlwriter   php7-zlib   $PHPRUN_DEPS   && rm -fr /var/cache/apk/*   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"   && php composer-setup.php   --install-dir=/usr/bin   --filename=composer   && php -r "unlink('composer-setup.php');"   && php -r "copy('https://github.com/drush-ops/drush/releases/download/8.1.16/drush.phar', '/usr/bin/drush');"   && chmod +x /usr/bin/drush
[WARNING]: Empty continuation lines will become errors in a future release.
```