### PR TITLE
Add php7-fileinfo new requirement of core

### DIFF
--- a/php56-fpm/Dockerfile
+++ b/php56-fpm/Dockerfile
@@ -34,6 +34,7 @@ RUN set -e \
   php5-ctype \
   php5-curl \
   php5-dom \
+  php5-fileinfo \
   php5-gd \
   php5-gmp \
   php5-iconv \

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -30,6 +30,7 @@ RUN set -e \
   php5-ctype \
   php5-curl \
   php5-dom \
+  php5-fileinfo \
   php5-gd \
   php5-gmp \
   php5-iconv \

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -29,6 +29,7 @@ RUN set -e \
   php7-ctype \
   php7-curl \
   php7-dom \
+  php7-fileinfo \
   php7-gd \
   php7-gmp \
   php7-iconv \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -29,6 +29,7 @@ RUN set -e \
   php7-ctype \
   php7-curl \
   php7-dom \
+  php7-fileinfo \
   php7-gd \
   php7-gmp \
   php7-iconv \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -32,6 +32,7 @@ RUN set -e \
   php7-ctype \
   php7-curl \
   php7-dom \
+  php7-fileinfo \
   php7-gd \
   php7-gmp \
   php7-iconv \


### PR DESCRIPTION
Fixing PHP images, new core dependency, will rebuild only 72
```
  Problem 1
    - typo3/phar-stream-wrapper v2.1.0 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
    - typo3/phar-stream-wrapper v2.1.0 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
    - Installation request for typo3/phar-stream-wrapper v2.1.0 -> satisfiable by typo3/phar-stream-wrapper[v2.1.0].
```