### PR TITLE
WIP: build 8.0 from artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 drupal
 db
 .idea
+php-build/context/keys
+php-build/context/packages

--- a/php-build/8-fpm/Dockerfile
+++ b/php-build/8-fpm/Dockerfile
@@ -1,0 +1,34 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM skilldlabs/php:8
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.name="docker-php" \
+  org.label-schema.description="PHP-FPM 7.4 Alpine for Drupal - git, composer, drush 8, sqlite, patch" \
+  org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
+  maintainer="Andy Postnikov <andypost@ya.ru>"
+
+RUN --mount=type=bind,source=keys,target=/var/cache/keys \
+  --mount=type=bind,source=packages/testing,target=/var/cache/php8 \
+  set -e \
+  && cp /var/cache/keys/alpine-infra@*.pub /etc/apk/keys/ \
+  && mkdir -p /var/www \
+  && addgroup -g 1000 -S www-data \
+  && adduser -u 1000 -D -S -G www-data www-data \
+  && apk add --no-cache -X /var/cache/php8 \
+  php8-fpm \
+  && rm /etc/apk/keys/alpine-infra@*.pub
+
+COPY php-fpm.conf /etc/php8/
+
+#USER www-data
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+EXPOSE 9000
+
+CMD ["php-fpm8", "-F"]

--- a/php-build/8/Dockerfile
+++ b/php-build/8/Dockerfile
@@ -1,0 +1,95 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM alpine:edge
+
+ARG COMPOSER_HASH
+ARG DRUSH_VERSION
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.name="docker-php" \
+  org.label-schema.description="PHP 8 Alpine for Drupal - git, composer, drush 8, sqlite, patch" \
+  org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
+  maintainer="Andy Postnikov <andypost@ya.ru>"
+
+ENV PHPRUN_DEPS \
+  curl \
+  git \
+  make \
+  mariadb-client \
+  openssh-client \
+  patch \
+  sqlite
+
+RUN --mount=type=bind,source=keys,target=/var/cache/keys \
+  --mount=type=bind,source=packages/testing,target=/var/cache/php8 \
+  set -e \
+  && cp /var/cache/keys/alpine-infra@*.pub /etc/apk/keys/ \
+  && apk add --upgrade -X /var/cache/php8 \
+  php8 \
+#  php8-pecl-apcu \
+#  php8-pecl-igbinary \
+#  php8-pecl-xdebug \
+  php8-bcmath \
+  php8-ctype \
+  php8-curl \
+  php8-dom \
+  php8-fileinfo \
+  php8-gd \
+  php8-gmp \
+  php8-iconv \
+#  php8-json \
+  php8-mbstring \
+  php8-opcache \
+  php8-openssl \
+  php8-pcntl \
+  php8-pdo_mysql \
+  php8-pdo_sqlite \
+  php8-phar \
+  php8-session \
+  php8-simplexml \
+  php8-tokenizer \
+  php8-xml \
+  php8-xmlreader \
+  php8-xmlwriter \
+  $PHPRUN_DEPS \
+  && ln -s /usr/bin/php8 /usr/bin/php \
+# build extra extensions
+  && apk add -X /var/cache/php8 --virtual .php-build \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  php8-dev php8-pear make gcc g++ \
+#  && sed -ie 's/-n//g' /usr/bin/pecl8 \
+  && CFLAGS="-Os -fomit-frame-pointer -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fvisibility=hidden -Wall -Wno-strict-aliasing" \
+  CPPFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie" \
+  pecl8 install apcu igbinary \
+  && echo 'extension=apcu' > /etc/php8/conf.d/apcu.ini \
+  && echo 'extension=igbinary' > /etc/php8/conf.d/10_igbinary.ini \
+  && strip /usr/lib/php8/modules/apcu.so /usr/lib/php8/modules/igbinary.so \
+  && wget https://github.com/xdebug/xdebug/archive/master.zip && unzip master.zip && rm master.zip \
+  && cd xdebug-master && phpize8 && ./configure --with-php-config=php-config8 \
+  && CFLAGS="-Os -fomit-frame-pointer -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fvisibility=hidden -Wall -Wno-strict-aliasing" \
+  CPPFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie" \
+  make install \
+  && cd .. && rm -rf xdebug-master \
+  && echo ';zend_extension=xdebug' > /etc/php8/conf.d/xdebug.ini \
+  && strip /usr/lib/php8/modules/xdebug.so \
+# clean-up
+  && apk del .php-build \
+  && rm -fr /tmp/pear /usr/include /usr/share/pear /usr/share/php8 /var/cache/apk/* \
+  /root/.drush/cache /etc/apk/keys/alpine-infra@*.pub \
+  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php \
+  --install-dir=/usr/bin \
+  --filename=composer \
+  && php -r "unlink('composer-setup.php');" \
+  && php -r "copy('https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar', '/usr/bin/drush');" \
+  && chmod +x /usr/bin/drush && /usr/bin/drush version
+
+COPY php.ini /etc/php8/conf.d/xx-drupal.ini
+
+WORKDIR /srv
+
+CMD ["php", "-t", "/srv", "-S", "0.0.0.0:80"]

--- a/php-build/Dockerfile
+++ b/php-build/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:edge
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.name="docker-php" \
+  org.label-schema.description="PHP 8 Alpine for Drupal - composer & drush" \
+  org.label-schema.vcs-url="https://github.com/skilld-labs/docker-php" \
+  maintainer="Andy Postnikov <andypost@ya.ru>"
+
+# Use to build updated PHP version with https://gitlab.alpinelinux.org/alpine/aports
+# then extract build artefacts in this directory.
+
+COPY ./keys/*.pub /etc/apk/keys/
+COPY ./packages/testing /var/cache/php8
+
+RUN set -e && echo "/var/cache/php8" >> /etc/apk/repositories \

--- a/php-build/Makefile
+++ b/php-build/Makefile
@@ -1,0 +1,32 @@
+NAME = skilldlabs/php
+TAGS ?= 8 8-fpm
+
+COMPOSER_HASH ?= 8a6138e2a05a8c28539c9f0fb361159823655d7ad2deecb371b04a83966c61223adc522b0189079e3e9e277cd72b8897
+DRUSH_VERSION ?= 8.4.1
+DOCKER_BUILDKIT ?= 1
+
+.PHONY: all build push
+
+all: build
+
+build:
+	@echo "Building images for tags: $(TAGS)"
+	set -e; for i in $(TAGS); do printf "\nBuilding $(NAME):$$i \n\n"; cd $$i; \
+		DOCKER_BUILDKIT=1 docker build -t $(NAME):$$i --no-cache \
+		--build-arg COMPOSER_HASH=$(COMPOSER_HASH) \
+		--build-arg DRUSH_VERSION=$(DRUSH_VERSION) \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		-f Dockerfile ../context; \
+		cd ..; done
+
+push:
+	@echo "Pushing images for tags: $(TAGS)"
+	set -e; for i in $(TAGS); do printf "\nPushing $(NAME):$$i \n\n"; docker push $(NAME):$$i; done
+
+package:
+	@echo "Packaging artefacts to image"
+	docker build -t $(NAME):8-build --no-cache \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		-f Dockerfile context; \

--- a/php-build/context/php-fpm.conf
+++ b/php-build/context/php-fpm.conf
@@ -1,0 +1,20 @@
+[global]
+error_log = /proc/self/fd/2
+log_level = notice
+daemonize = no
+
+[app]
+user = www-data
+group = www-data
+listen = [::]:9000
+access.log = /proc/self/fd/2
+catch_workers_output = yes
+clear_env = no
+security.limit_extensions = .php
+
+pm = ondemand
+pm.max_children = 4
+pm.max_requests = 100
+pm.process_idle_timeout = 30
+
+php_value[memory_limit] = 512M

--- a/php-build/context/php.ini
+++ b/php-build/context/php.ini
@@ -1,0 +1,38 @@
+; PHP limits
+memory_limit = 512M
+max_input_time = 240
+max_execution_time = 240
+
+upload_max_filesize = 200M
+post_max_size = 200M
+
+; XDebug configuration
+xdebug.remote_enable = 1
+xdebug.remote_connect_back = 1
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 2000
+xdebug.profiler_enable = 0
+xdebug.profiler_enable_trigger = 1
+xdebug.profiler_output_dir = "/var/log"
+
+; Show PHP errors
+display_errors = On
+error_reporting = E_ALL | E_STRICT
+
+; Use PHP short tags
+short_open_tag = Off
+
+; OPCache configuration
+opcache.memory_consumption = 196
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 10000
+opcache.revalidate_freq = 0
+opcache.validate_timestamps = 1
+opcache.fast_shutdown = 1
+opcache.enable_cli = 1
+
+apc.shm_size = 128M
+apc.enable_cli = 1
+
+cgi.fix_pathinfo = 0;
+always_populate_raw_post_data = -1

--- a/php-build/readme.txt
+++ b/php-build/readme.txt
@@ -1,0 +1,3 @@
+Images supposed to use merge request artifacts from Alpinelinux
+- use to unpack artifacts with "unzip MR* -d context"
+- run "make" and then "make push"


### PR DESCRIPTION
**Do not merge it!**

Using https://github.com/skilld-labs/docker-php/pull/60 we could build php8 from artifacts

- APCu, igbinary installs and works fine
- xdebug using git-master and waiting 3.0 release
- needs to review JIT settings for opcache

Pushed `skilldlabs/php:8` and  `skilldlabs/php:8-fpm`
