### PR TITLE
Use default xdebug 3 client_port

### DIFF
--- a/php73-fpm-dev/Dockerfile
+++ b/php73-fpm-dev/Dockerfile
@@ -27,7 +27,6 @@ RUN apk add --update php7-pecl-xhprof \
   && echo '; Configure mode https://3.xdebug.org/docs/all_settings#xdebug.mode' >> /etc/php7/conf.d/50_xdebug.ini \
   && echo 'xdebug.mode=debug' >> /etc/php7/conf.d/50_xdebug.ini \
   && echo 'xdebug.discover_client_host=1' >> /etc/php7/conf.d/50_xdebug.ini \
-  && echo 'xdebug.client_port=9000' >> /etc/php7/conf.d/50_xdebug.ini \
   && echo 'xdebug.profiler_output_name=cachegrind.out.%p.%r' >> /etc/php7/conf.d/50_xdebug.ini \
   && strip /usr/lib/php7/modules/xdebug.so \
   && php7 -dzend_extension=xdebug -r 'xdebug_info();' \

--- a/php74-fpm-dev/Dockerfile
+++ b/php74-fpm-dev/Dockerfile
@@ -28,7 +28,6 @@ RUN apk add --no-cache php7-pecl-xhprof \
 #  && echo '; Configure mode https://xdebug.org/docs/all_settings#xdebug.mode' >> /etc/php7/conf.d/50_xdebug.ini \
 #  && echo 'xdebug.mode=debug' >> /etc/php7/conf.d/50_xdebug.ini \
 #  && echo 'xdebug.discover_client_host=1' >> /etc/php7/conf.d/50_xdebug.ini \
-#  && echo 'xdebug.client_port=9000' >> /etc/php7/conf.d/50_xdebug.ini \
 #  && echo 'xdebug.profiler_output_name=cachegrind.out.%p.%r' >> /etc/php7/conf.d/50_xdebug.ini \
 #  && strip /usr/lib/php7/modules/xdebug.so \
 #  && php7 -dzend_extension=xdebug -r 'xdebug_info();' \

--- a/php74/Dockerfile
+++ b/php74/Dockerfile
@@ -63,7 +63,6 @@ RUN set -e \
 #  && echo 'extension=apcu.so' > /etc/php7/conf.d/apcu.ini \
   && echo 'xdebug.mode=debug' >> /etc/php7/conf.d/50_xdebug.ini \
   && echo 'xdebug.discover_client_host=1' >> /etc/php7/conf.d/50_xdebug.ini \
-  && echo 'xdebug.client_port=9000' >> /etc/php7/conf.d/50_xdebug.ini \
   && echo 'xdebug.profiler_output_name=cachegrind.out.%p.%r' >> /etc/php7/conf.d/50_xdebug.ini \
 # clean-up
 #  && apk del --no-network .php-build \

--- a/php8/php.ini
+++ b/php8/php.ini
@@ -11,7 +11,6 @@ xdebug.max_nesting_level = 2000
 
 xdebug.mode=debug
 xdebug.discover_client_host=1
-xdebug.client_port=9000
 
 ; Show PHP errors
 display_errors = On


### PR DESCRIPTION
Ref https://xdebug.org/docs/all_settings#client_port

PS: Phpstorm has support for new and old ports https://www.jetbrains.com/help/phpstorm/configuring-xdebug.html#integrationWithProduct