### PR TITLE
Remove composer 1.x from php 8.0/8.1 images

### DIFF
--- a/php8/Dockerfile
+++ b/php8/Dockerfile
@@ -83,10 +83,6 @@ RUN set -e \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php \
   --install-dir=/usr/bin \
-  --filename=composer1 \
-  --1 \
-  && php composer-setup.php \
-  --install-dir=/usr/bin \
   --filename=composer2 \
   --2 \
   && ln -s composer2 /usr/bin/composer \

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -83,10 +83,6 @@ RUN set -e \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_HASH')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php \
   --install-dir=/usr/bin \
-  --filename=composer1 \
-  --1 \
-  && php composer-setup.php \
-  --install-dir=/usr/bin \
   --filename=composer2 \
   --2 \
   && ln -s composer2 /usr/bin/composer \


### PR DESCRIPTION
No need for it with php 8 - clean-up after https://github.com/skilld-labs/docker-php/issues/67