### PR TITLE
Use Alpinelinux 3.14 for PHP 7.4

### DIFF
--- a/php74/Dockerfile
+++ b/php74/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.14
 
 ARG COMPOSER_HASH
 ARG DRUSH_VERSION


### PR DESCRIPTION
Next month Alpine will get lots updates before 3.15 release