### PR TITLE
Use buildx to support multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAGS ?= 81 81-fpm 81-unit 82 82-fpm 82-unit
 COMPOSER_HASH ?= 55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae
 DRUSH_VERSION ?= 8.4.12
 DOCKER_BUILDKIT ?= 1
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux/amd64,linux/arm64
 
 .PHONY: all build push
 
@@ -14,7 +14,6 @@ build:
 	@echo "Building images for tags: $(TAGS)"
 	set -e; for i in $(TAGS); do printf "\nBuilding $(NAME):$$i \n\n"; cd php$$i; \
 		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -t $(NAME):$$i \
-		--platform $(PLATFORM) \
 		--no-cache --progress=plain \
 		--build-arg COMPOSER_HASH=$(COMPOSER_HASH) \
 		--build-arg DRUSH_VERSION=$(DRUSH_VERSION) \
@@ -28,3 +27,15 @@ push:
 
 unit:
 	make -C unit-php-builder/dev build
+
+buildx-push:
+	@echo "Building and pushing images for tags: $(TAGS)"
+		set -e; for i in $(TAGS); do printf "\nBuilding $(NAME):$$i \n\n"; cd php$$i; \
+		docker buildx build -t $(NAME):$$i --push \
+		--platform $(PLATFORM) \
+		--no-cache --progress=plain \
+		--build-arg COMPOSER_HASH=$(COMPOSER_HASH) \
+		--build-arg DRUSH_VERSION=$(DRUSH_VERSION) \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` .; \
+		cd ..; done


### PR DESCRIPTION
To provide multi-arch images, we have to use `buildx` in the builds.
Due to standard `build` command doesn't support multi-arch builds, and `buildx --load` [doesn't allow making multi-arch images locally also](https://github.com/docker/buildx/issues/59), `make build` must only be used for building images locally for the current arch.
New target `make buildx-push` is introduced to create multi-arch images and is intended to build and push images to Docker Hub as a default way.

We have to agree on the best build flow here and maybe introduce github actions to simplify the build procedure.
We must also rebuild the images for php74 to support older projects.
