### PR TITLE
Add brotli compression support

### DIFF
--- a/php8/Dockerfile
+++ b/php8/Dockerfile
@@ -29,6 +29,7 @@ RUN set -e \
   && echo 'https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
   && apk add --upgrade \
   php8 \
+  php8-brotli \
   php8-pecl-apcu \
   php8-pecl-igbinary \
   php8-pecl-uploadprogress \

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -29,6 +29,7 @@ RUN set -e \
   && echo 'https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
   && apk add --upgrade \
   php81 \
+  php81-brotli \
   php81-pecl-apcu \
   php81-pecl-igbinary \
   php81-pecl-uploadprogress \

--- a/php82/Dockerfile
+++ b/php82/Dockerfile
@@ -29,6 +29,7 @@ RUN set -e \
   && echo 'https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
   && apk add --upgrade \
   php82 \
+  php82-brotli \
   php82-pecl-apcu \
   php82-pecl-igbinary \
   php82-pecl-uploadprogress \


### PR DESCRIPTION
It's just 70KB with a set of benefits

All optimized files can be pre-compressed with the newer brotli compression algorithm; this often shows close to 30% improvements in file size vs gzip. Requires the brotli php extension is installed.

Ref https://www.drupal.org/docs/contributed-modules/advanced-cssjs-aggregation/advanced-aggregates#brotli