### PR TITLE
UNIT: app log should be rerouted to stdout

### DIFF
--- a/php81-unit/Dockerfile
+++ b/php81-unit/Dockerfile
@@ -26,4 +26,4 @@ RUN set -e && \
   addgroup -g 1000 -S web-group && \
   adduser -u 1000 -D -S -G web-group web-user
 
-CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group"]
+CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group", "--log", "/dev/stdout"]

--- a/php82-unit/Dockerfile
+++ b/php82-unit/Dockerfile
@@ -26,4 +26,4 @@ RUN set -e && \
   addgroup -g 1000 -S web-group && \
   adduser -u 1000 -D -S -G web-group web-user
 
-CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group"]
+CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group", "--log", "/dev/stdout"]

--- a/php83-unit/Dockerfile
+++ b/php83-unit/Dockerfile
@@ -26,4 +26,4 @@ RUN set -e && \
   addgroup -g 1000 -S web-group && \
   adduser -u 1000 -D -S -G web-group web-user
 
-CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group"]
+CMD ["unitd", "--no-daemon", "--user", "web-user", "--group", "web-group", "--log", "/dev/stdout"]


### PR DESCRIPTION
- the --no-daemon settiing it to /var/log/unit.log
- CMD should override instead of symlink

https://unit.nginx.org/news/2023/unit-1.30.0-released/#application-logging

> By default, application logging is directed to `/dev/null` (no output). However, if `unitd` is started with the `--no-daemon` option, application logging is sent to the console.